### PR TITLE
feat: replaces gnome dependencies with cosmic components

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -197,49 +197,49 @@ Package: regolith-i3-control-center-regolith
 Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config,
-  regolith-control-center,
-  gnome-settings-daemon
+  cosmic-settings,
+  cosmic-session
 Provides: regolith-wm-control-center
 Conflicts: regolith-wm-gnome, regolith-i3-control-center-gnome
 Replaces: regolith-wm-gnome, regolith-i3-control-center-gnome
-Description: regolith and gnome integrations for system management
- Launch regolith settings app for system management.
+Description: regolith and cosmic integrations for system management
+ Launch cosmic settings app for system management.
 
 Package: regolith-sway-control-center-regolith
 Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config,
-  regolith-control-center,
-  gnome-settings-daemon
+  cosmic-settings,
+  cosmic-session
 Provides: regolith-wm-control-center
 Conflicts: regolith-wm-gnome, regolith-sway-control-center-gnome
 Replaces: regolith-wm-gnome, regolith-sway-control-center-gnome
-Description: regolith and gnome integrations for system management
- Launch regolith settings app for system management.
+Description: regolith and cosmic integrations for system management
+ Launch cosmic settings app for system management.
 
 Package: regolith-sway-control-center-gnome
 Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config,
-  gnome-control-center,
-  gnome-settings-daemon
+  cosmic-settings,
+  cosmic-session
 Provides: regolith-wm-control-center
 Conflicts: regolith-wm-gnome, regolith-sway-control-center-regolith
 Replaces: regolith-wm-gnome, regolith-sway-control-center-regolith
-Description: regolith and gnome integrations for system management
- Launch gnome settings app for system management.
+Description: regolith and cosmic integrations for system management
+ Launch cosmic settings app for system management.
 
 Package: regolith-i3-control-center-gnome
 Architecture: any
 Depends: ${misc:Depends},
   regolith-wm-config,
-  gnome-control-center,
-  gnome-settings-daemon
+  cosmic-settings,
+  cosmic-session
 Provides: regolith-wm-control-center
 Conflicts: regolith-wm-gnome, regolith-i3-control-center-regolith
 Replaces: regolith-wm-gnome, regolith-i3-control-center-regolith
-Description: gnome integrations for system management
- Launch gnome settings app for system management.
+Description: cosmic integrations for system management
+ Launch cosmic settings app for system management.
 
 Package: regolith-i3-next-workspace
 Architecture: any
@@ -328,7 +328,7 @@ Depends: ${misc:Depends},
   regolith-displayd (>=0.3.0),
   regolith-wm-config (>=4.6.1)
 Description: Configuration for providing functionality equivalent
-  to gnome-settings-daemon.
+  to gnome-settings-daemon using cosmic components.
 
 Package: regolith-sway-media-keys
 Architecture: any
@@ -352,13 +352,15 @@ Depends: ${misc:Depends},
     file,
     jq,
     trawlcat,
+    cosmic-bg,
     regolith-wm-config
-Description: Configuration for providing media key functionality
+Description: Configuration for providing cosmic background functionality
 
 
 Package: regolith-sway-polkit
 Architecture: any
 Depends: ${misc:Depends},
+    cosmic-osd,
     mate-polkit-bin,
     regolith-wm-config
 Conflicts: regolith-sway-polkit-xwayland
@@ -375,17 +377,17 @@ Description: Configuration for providing media key functionality
 Package: regolith-sway-gtklock
 Architecture: any
 Depends: ${misc:Depends},
-    gtklock,
-    trawlcat,
+    cosmic-session,
     regolith-wm-config,
-Description: Configuration for using gtklock as the default locker
+Description: Configuration for using cosmic-session lock as the default locker
 
 Package: regolith-sway-audio-idle-inhibit
 Architecture: any
 Depends: ${misc:Depends},
     sway-audio-idle-inhibit,
+    cosmic-idle,
     regolith-wm-config
-Description: Prevent sway from entering idle state if audio is playing
+Description: Prevent sway from entering idle state using cosmic-idle
 
 Package: regolith-sway-unclutter
 Architecture: any

--- a/debian/regolith-cosmic-idle.install
+++ b/debian/regolith-cosmic-idle.install
@@ -1,0 +1,1 @@
+usr/share/regolith/sway/config.d/82_cosmic_idle

--- a/debian/regolith-cosmic-settings-daemon.install
+++ b/debian/regolith-cosmic-settings-daemon.install
@@ -1,0 +1,1 @@
+/usr/share/regolith/sway/config.d/76_cosmic_settings_daemon

--- a/debian/regolith-sway-gtklock.install
+++ b/debian/regolith-sway-gtklock.install
@@ -1,1 +1,1 @@
-usr/share/regolith/sway/config.d/42_gtklock
+usr/share/regolith/sway/config.d/42_gtk_lock

--- a/etc/regolith/sway/config
+++ b/etc/regolith/sway/config
@@ -179,6 +179,8 @@ include $HOME/.config/regolith3/common-wm/config.d/*
 # Include any user wm partials
 include $HOME/.config/regolith3/sway/config.d/*
 
+include $HOME/.config/regolith3/sway/cosmic-settings/generated-config.d/*
+
 # Start the systemd target manually is the session is not started by systemd
 # Notify systemd about successful session start otherwise
 exec --no-startup-id [ -z "${NOTIFY_SOCKET-}" ] \

--- a/scripts/regolith-sway-clamshell
+++ b/scripts/regolith-sway-clamshell
@@ -25,7 +25,7 @@ get_lid_close_cmd() {
   local LOCK=$( trawlcat wm.program.lock "$DEFAULT_LOCK")
   local SLEEP=$( trawlcat wm.program.sleep "systemctl suspend" )
   local HIBERNATE=$( trawlcat wm.program.hibernate "systemctl hibernate" )
-  local SHUTDOWN=$( trawlcat wm.program.shutdown "gnome-session-quit --power-off --no-prompt")
+  local SHUTDOWN=$( trawlcat wm.program.shutdown "systemctl poweroff")
 
   case "$1" in
     "DO_NOTHING")

--- a/usr/share/regolith/i3/config.d/60_config_keybindings
+++ b/usr/share/regolith/i3/config.d/60_config_keybindings
@@ -1,33 +1,52 @@
-###############################################################################
+########################## Launch // File Browser // <><Shift> n ##
+set_from_resource $wm.binding.files wm.binding.files Shift+n
+set_from_resource $wm.program.files wm.program.files cosmic-files
+bindsym $mod+$wm.binding.files exec --no-startup-id $wm.program.files###################################################
 # System Management
 ###############################################################################
 
 ## Modify // Settings // <> c ##
 set_from_resource $wm.binding.settings wm.binding.settings c
-set_from_resource $wm.program.settings wm.program.settings regolith-control-center
+set_from_resource $wm.program.settings wm.program.settings cosmic-settings
 bindsym $mod+$wm.binding.settings exec --no-startup-id $wm.program.settings
 
 ## Modify // Display Settings // <> d ##
 set_from_resource $wm.binding.display wm.binding.display d
-set_from_resource $wm.program.display wm.program.display regolith-control-center display
+set_from_resource $wm.program.display wm.program.display cosmic-settings displays
 bindsym $mod+$wm.binding.display exec --no-startup-id $wm.program.display
 
 ## Modify // Wifi Settings // <> w ##
 set_from_resource $wm.binding.wifi wm.binding.wifi w
-set_from_resource $wm.program.wifi wm.program.wifi regolith-control-center wifi
+set_from_resource $wm.program.wifi wm.program.wifi cosmic-settings wireless
 bindsym $mod+$wm.binding.wifi exec --no-startup-id $wm.program.wifi
 
 ## Modify // Bluetooth Settings // <> b ##
 set_from_resource $wm.binding.bluetooth wm.binding.bluetooth b
-set_from_resource $wm.program.bluetooth wm.program.bluetooth regolith-control-center bluetooth
+set_from_resource $wm.program.bluetooth wm.program.bluetooth cosmic-settings bluetooth
 bindsym $mod+$wm.binding.bluetooth exec --no-startup-id $wm.program.bluetooth
+
+## Modify // Sound Settings // <><Shift> a ##
+set_from_resource $wm.binding.sound wm.binding.sound Shift+a
+set_from_resource $wm.program.sound wm.program.sound cosmic-settings sound
+bindsym $mod+$wm.binding.sound exec --no-startup-id $wm.program.sound
+
+## Modify // Power Settings // <><Shift> p ##
+set_from_resource $wm.binding.power wm.binding.power Shift+p
+set_from_resource $wm.program.power wm.program.power cosmic-settings power
+bindsym $mod+$wm.binding.power exec --no-startup-id $wm.program.power
+
+## Modify // Appearance Settings // <><Shift> t ##
+set_from_resource $wm.binding.appearance wm.binding.appearance Shift+t
+set_from_resource $wm.program.appearance wm.program.appearance cosmic-settings appearance
+bindsym $mod+$wm.binding.appearance exec --no-startup-id $wm.program.appearance
 
 ## Launch // File Browser // <><Shift> n ##
 set_from_resource $wm.binding.files wm.binding.files Shift+n
-set_from_resource $wm.program.files wm.program.files /usr/bin/nautilus --new-window
+set_from_resource $wm.program.files wm.program.files cosmic-files
 bindsym $mod+$wm.binding.files exec --no-startup-id $wm.program.files
 
-for_window [class="regolith-control-center"] floating enable
+for_window [class="cosmic-settings"] floating enable
 
-set_from_resource $wm.program.media-keys wm.program.media-keys /usr/libexec/gnome-flashback-media-keys
-exec --no-startup-id $wm.program.media-keys
+# cosmic alternative to be added
+# set_from_resource $wm.program.media-keys wm.program.media-keys /usr/libexec/gnome-flashback-media-keys
+# exec --no-startup-id $wm.program.media-keys

--- a/usr/share/regolith/i3/config.d/60_config_keybindings
+++ b/usr/share/regolith/i3/config.d/60_config_keybindings
@@ -1,7 +1,3 @@
-########################## Launch // File Browser // <><Shift> n ##
-set_from_resource $wm.binding.files wm.binding.files Shift+n
-set_from_resource $wm.program.files wm.program.files cosmic-files
-bindsym $mod+$wm.binding.files exec --no-startup-id $wm.program.files###################################################
 # System Management
 ###############################################################################
 
@@ -24,21 +20,6 @@ bindsym $mod+$wm.binding.wifi exec --no-startup-id $wm.program.wifi
 set_from_resource $wm.binding.bluetooth wm.binding.bluetooth b
 set_from_resource $wm.program.bluetooth wm.program.bluetooth cosmic-settings bluetooth
 bindsym $mod+$wm.binding.bluetooth exec --no-startup-id $wm.program.bluetooth
-
-## Modify // Sound Settings // <><Shift> a ##
-set_from_resource $wm.binding.sound wm.binding.sound Shift+a
-set_from_resource $wm.program.sound wm.program.sound cosmic-settings sound
-bindsym $mod+$wm.binding.sound exec --no-startup-id $wm.program.sound
-
-## Modify // Power Settings // <><Shift> p ##
-set_from_resource $wm.binding.power wm.binding.power Shift+p
-set_from_resource $wm.program.power wm.program.power cosmic-settings power
-bindsym $mod+$wm.binding.power exec --no-startup-id $wm.program.power
-
-## Modify // Appearance Settings // <><Shift> t ##
-set_from_resource $wm.binding.appearance wm.binding.appearance Shift+t
-set_from_resource $wm.program.appearance wm.program.appearance cosmic-settings appearance
-bindsym $mod+$wm.binding.appearance exec --no-startup-id $wm.program.appearance
 
 ## Launch // File Browser // <><Shift> n ##
 set_from_resource $wm.binding.files wm.binding.files Shift+n

--- a/usr/share/regolith/i3/config.d/60_gnome_config_keybindings
+++ b/usr/share/regolith/i3/config.d/60_gnome_config_keybindings
@@ -4,30 +4,30 @@
 
 ## Modify // Settings // <> c ##
 set_from_resource $wm.binding.settings wm.binding.settings c
-set_from_resource $wm.program.settings wm.program.settings gnome-control-center
+set_from_resource $wm.program.settings wm.program.settings cosmic-settings
 bindsym $mod+$wm.binding.settings exec --no-startup-id $wm.program.settings
 
 ## Modify // Display Settings // <> d ##
 set_from_resource $wm.binding.display wm.binding.display d
-set_from_resource $wm.program.display wm.program.display gnome-control-center display
+set_from_resource $wm.program.display wm.program.display cosmic-settings displays
 bindsym $mod+$wm.binding.display exec --no-startup-id $wm.program.display
 
 ## Modify // Wifi Settings // <> w ##
 set_from_resource $wm.binding.wifi wm.binding.wifi w
-set_from_resource $wm.program.wifi wm.program.wifi gnome-control-center wifi
+set_from_resource $wm.program.wifi wm.program.wifi cosmic-settings wireless
 bindsym $mod+$wm.binding.wifi exec --no-startup-id $wm.program.wifi
 
 ## Modify // Bluetooth Settings // <> b ##
 set_from_resource $wm.binding.bluetooth wm.binding.bluetooth b
-set_from_resource $wm.program.bluetooth wm.program.bluetooth gnome-control-center bluetooth
+set_from_resource $wm.program.bluetooth wm.program.bluetooth cosmic-settings bluetooth
 bindsym $mod+$wm.binding.bluetooth exec --no-startup-id $wm.program.bluetooth
 
 ## Launch // File Browser // <><Shift> n ##
 set_from_resource $wm.binding.files wm.binding.files Shift+n
-set_from_resource $wm.program.files wm.program.files /usr/bin/nautilus --new-window
+set_from_resource $wm.program.files wm.program.files cosmic-files
 bindsym $mod+$wm.binding.files exec --no-startup-id $wm.program.files
 
-for_window [class="gnome-control-center"] floating enable
+for_window [class="cosmic-settings"] floating enable
 
-set_from_resource $wm.program.media-keys wm.program.media-keys /usr/libexec/gnome-flashback-media-keys
+set_from_resource $wm.program.media-keys wm.program.media-keys cosmic-session
 exec --no-startup-id $wm.program.media-keys

--- a/usr/share/regolith/sway/config.d/55_session_keybindings
+++ b/usr/share/regolith/sway/config.d/55_session_keybindings
@@ -1,4 +1,3 @@
-###############################################################################
 # Session Management
 ###############################################################################
 
@@ -24,23 +23,28 @@ bindsym $mod+$wm.binding.refresh exec $wm.program.refresh_ui
 
 ## Session // Logout // <><Shift> e ##
 set_from_resource $wm.binding.logout wm.binding.logout Shift+e
-set_from_resource $wm.program.logout wm.program.logout /usr/bin/gnome-session-quit --logout --no-prompt && swaymsg exit
+set_from_resource $wm.program.logout wm.program.logout loginctl logout && swaymsg exit
 set_from_resource $sway.prompt.logout sway.prompt.logout "swaynag -t warning -m 'Do you really want to logout?' -b 'Logout' '$wm.program.logout'"
 bindsym $mod+$wm.binding.logout exec $sway.prompt.logout 
 
 ## Session // Reboot // <><Shift> b ##
 set_from_resource $wm.binding.reboot wm.binding.reboot Shift+b
-set_from_resource $wm.program.reboot wm.program.reboot /usr/bin/gnome-session-quit --reboot --no-prompt
+set_from_resource $wm.program.reboot wm.program.reboot loginctl reboot
 set_from_resource $sway.prompt.reboot sway.prompt.reboot "swaynag -t warning -m 'Do you really want to reboot your system?' -b 'Reboot' '$wm.program.reboot'"
 bindsym $mod+$wm.binding.reboot exec $sway.prompt.reboot 
 
 ## Session // Power Down // <><Shift> p ##
 set_from_resource $wm.binding.shutdown wm.binding.shutdown Shift+p
-set_from_resource $wm.program.shutdown wm.program.shutdown /usr/bin/gnome-session-quit --power-off --no-prompt
+set_from_resource $wm.program.shutdown wm.program.shutdown loginctl poweroff
 set_from_resource $sway.prompt.shutdown sway.prompt.shutdown "swaynag -t warning -m 'Do you really want to shutdown' -b 'Shutdown' '$wm.program.shutdown'"
 bindsym $mod+$wm.binding.shutdown exec $sway.prompt.shutdown 
 
+## Session // Lock Screen // <> Escape ##
+set_from_resource $wm.binding.lock wm.binding.lock Escape
+set_from_resource $wm.program.lock wm.program.lock loginctl lock-session
+bindsym $mod+$wm.binding.lock exec $wm.program.lock
+
 ## Session // Sleep // <><Shift> s ##
 set_from_resource $wm.binding.sleep wm.binding.sleep Shift+s
-set_from_resource $wm.program.sleep wm.program.sleep systemctl suspend
+set_from_resource $wm.program.sleep wm.program.sleep loginctl suspend
 bindsym --locked $mod+$wm.binding.sleep exec $wm.program.sleep

--- a/usr/share/regolith/sway/config.d/60_config_keybindings
+++ b/usr/share/regolith/sway/config.d/60_config_keybindings
@@ -1,30 +1,44 @@
-###############################################################################
 # System Management
 ###############################################################################
 
 ## Modify // Settings // <> c ##
 set_from_resource $wm.binding.settings wm.binding.settings c
-set_from_resource $wm.program.settings wm.program.settings regolith-control-center
+set_from_resource $wm.program.settings wm.program.settings cosmic-settings
 bindsym $mod+$wm.binding.settings exec --no-startup-id $wm.program.settings
 
 ## Modify // Display Settings // <> d ##
 set_from_resource $wm.binding.display wm.binding.display d
-set_from_resource $wm.program.display wm.program.display regolith-control-center display
+set_from_resource $wm.program.display wm.program.display cosmic-settings displays
 bindsym $mod+$wm.binding.display exec --no-startup-id $wm.program.display
 
 ## Modify // Wifi Settings // <> w ##
 set_from_resource $wm.binding.wifi wm.binding.wifi w
-set_from_resource $wm.program.wifi wm.program.wifi regolith-control-center wifi
+set_from_resource $wm.program.wifi wm.program.wifi cosmic-settings wireless
 bindsym $mod+$wm.binding.wifi exec --no-startup-id $wm.program.wifi
 
 ## Modify // Bluetooth Settings // <> b ##
 set_from_resource $wm.binding.bluetooth wm.binding.bluetooth b
-set_from_resource $wm.program.bluetooth wm.program.bluetooth regolith-control-center bluetooth
+set_from_resource $wm.program.bluetooth wm.program.bluetooth cosmic-settings bluetooth
 bindsym $mod+$wm.binding.bluetooth exec --no-startup-id $wm.program.bluetooth
+
+## Modify // Sound Settings // <><Shift> a ##
+set_from_resource $wm.binding.sound wm.binding.sound Shift+a
+set_from_resource $wm.program.sound wm.program.sound cosmic-settings sound
+bindsym $mod+$wm.binding.sound exec --no-startup-id $wm.program.sound
+
+## Modify // Power Settings // <><Shift> p ##
+set_from_resource $wm.binding.power wm.binding.power Shift+p
+set_from_resource $wm.program.power wm.program.power cosmic-settings power
+bindsym $mod+$wm.binding.power exec --no-startup-id $wm.program.power
+
+## Modify // Appearance Settings // <><Shift> t ##
+set_from_resource $wm.binding.appearance wm.binding.appearance Shift+t
+set_from_resource $wm.program.appearance wm.program.appearance cosmic-settings appearance
+bindsym $mod+$wm.binding.appearance exec --no-startup-id $wm.program.appearance
 
 ## Launch // File Browser // <><Shift> n ##
 set_from_resource $wm.binding.files wm.binding.files Shift+n
-set_from_resource $wm.program.files wm.program.files /usr/bin/nautilus --new-window
+set_from_resource $wm.program.files wm.program.files cosmic-files
 bindsym $mod+$wm.binding.files exec --no-startup-id $wm.program.files
 
-for_window [app_id="org.regolith.Settings"] floating enable
+for_window [app_id="com.system76.CosmicSettings"] floating enable

--- a/usr/share/regolith/sway/config.d/60_config_keybindings
+++ b/usr/share/regolith/sway/config.d/60_config_keybindings
@@ -21,21 +21,6 @@ set_from_resource $wm.binding.bluetooth wm.binding.bluetooth b
 set_from_resource $wm.program.bluetooth wm.program.bluetooth cosmic-settings bluetooth
 bindsym $mod+$wm.binding.bluetooth exec --no-startup-id $wm.program.bluetooth
 
-## Modify // Sound Settings // <><Shift> a ##
-set_from_resource $wm.binding.sound wm.binding.sound Shift+a
-set_from_resource $wm.program.sound wm.program.sound cosmic-settings sound
-bindsym $mod+$wm.binding.sound exec --no-startup-id $wm.program.sound
-
-## Modify // Power Settings // <><Shift> p ##
-set_from_resource $wm.binding.power wm.binding.power Shift+p
-set_from_resource $wm.program.power wm.program.power cosmic-settings power
-bindsym $mod+$wm.binding.power exec --no-startup-id $wm.program.power
-
-## Modify // Appearance Settings // <><Shift> t ##
-set_from_resource $wm.binding.appearance wm.binding.appearance Shift+t
-set_from_resource $wm.program.appearance wm.program.appearance cosmic-settings appearance
-bindsym $mod+$wm.binding.appearance exec --no-startup-id $wm.program.appearance
-
 ## Launch // File Browser // <><Shift> n ##
 set_from_resource $wm.binding.files wm.binding.files Shift+n
 set_from_resource $wm.program.files wm.program.files cosmic-files

--- a/usr/share/regolith/sway/config.d/60_gnome_config_keybindings
+++ b/usr/share/regolith/sway/config.d/60_gnome_config_keybindings
@@ -4,27 +4,27 @@
 
 ## Modify // Settings // <> c ##
 set_from_resource $wm.binding.settings wm.binding.settings c
-set_from_resource $wm.program.settings wm.program.settings gnome-control-center
+set_from_resource $wm.program.settings wm.program.settings cosmic-settings
 bindsym $mod+$wm.binding.settings exec --no-startup-id $wm.program.settings
 
 ## Modify // Display Settings // <> d ##
 set_from_resource $wm.binding.display wm.binding.display d
-set_from_resource $wm.program.display wm.program.display gnome-control-center display
+set_from_resource $wm.program.display wm.program.display cosmic-settings displays
 bindsym $mod+$wm.binding.display exec --no-startup-id $wm.program.display
 
 ## Modify // Wifi Settings // <> w ##
 set_from_resource $wm.binding.wifi wm.binding.wifi w
-set_from_resource $wm.program.wifi wm.program.wifi gnome-control-center wifi
+set_from_resource $wm.program.wifi wm.program.wifi cosmic-settings wireless
 bindsym $mod+$wm.binding.wifi exec --no-startup-id $wm.program.wifi
 
 ## Modify // Bluetooth Settings // <> b ##
 set_from_resource $wm.binding.bluetooth wm.binding.bluetooth b
-set_from_resource $wm.program.bluetooth wm.program.bluetooth gnome-control-center bluetooth
+set_from_resource $wm.program.bluetooth wm.program.bluetooth cosmic-settings bluetooth
 bindsym $mod+$wm.binding.bluetooth exec --no-startup-id $wm.program.bluetooth
 
 ## Launch // File Browser // <><Shift> n ##
 set_from_resource $wm.binding.files wm.binding.files Shift+n
-set_from_resource $wm.program.files wm.program.files /usr/bin/nautilus --new-window
+set_from_resource $wm.program.files wm.program.files cosmic-files
 bindsym $mod+$wm.binding.files exec --no-startup-id $wm.program.files
 
-for_window [class="gnome-control-center"] floating enable
+for_window [class="cosmic-settings"] floating enable

--- a/usr/share/regolith/sway/config.d/65_media_keybindings
+++ b/usr/share/regolith/sway/config.d/65_media_keybindings
@@ -2,15 +2,15 @@
 
 # Volume Controls
 set_from_resource $wm.media.volume.step sway.media.volume.step 5
-bindsym --locked XF86AudioRaiseVolume exec volumectl -u + $wm.media.volume.step
-bindsym --locked XF86AudioLowerVolume exec volumectl -u - $wm.media.volume.step
-bindsym --locked XF86AudioMute exec volumectl %
-bindsym --locked XF86AudioMicMute exec volumectl -m %
+bindsym --locked XF86AudioRaiseVolume exec pactl set-sink-volume @DEFAULT_SINK@ +$wm.media.volume.step%
+bindsym --locked XF86AudioLowerVolume exec pactl set-sink-volume @DEFAULT_SINK@ -$wm.media.volume.step%
+bindsym --locked XF86AudioMute exec pactl set-sink-mute @DEFAULT_SINK@ toggle
+bindsym --locked XF86AudioMicMute exec pactl set-source-mute @DEFAULT_SOURCE@ toggle
 
 # Brightness Controls
 set_from_resource $wm.media.brightness.step wm.media.brightness.step 5
-bindsym XF86MonBrightnessUp exec lightctl + $wm.media.brightness.step
-bindsym XF86MonBrightnessDown exec lightctl - $wm.media.brightness.step
+bindsym --locked XF86MonBrightnessUp exec brightnessctl set $wm.media.brightness.step%+
+bindsym --locked XF86MonBrightnessDown exec brightnessctl set $wm.media.brightness.step%-
 
 # Player Controls
 # The keycodes 172 and 208 are both bound to XF86AudioPlay but have different meanings

--- a/usr/share/regolith/sway/config.d/76_cosmic_settings_daemon
+++ b/usr/share/regolith/sway/config.d/76_cosmic_settings_daemon
@@ -1,0 +1,1 @@
+exec cosmic-settings-daemon

--- a/usr/share/regolith/sway/config.d/80_swaybg
+++ b/usr/share/regolith/sway/config.d/80_swaybg
@@ -1,1 +1,2 @@
-exec_always --no-startup-id /usr/bin/regolith-set-swaybg
+exec_always --no-startup-id /usr/bin/cosmic-bg
+

--- a/usr/share/regolith/sway/config.d/82_cosmic_idle
+++ b/usr/share/regolith/sway/config.d/82_cosmic_idle
@@ -1,0 +1,1 @@
+exec cosmic-idle

--- a/usr/share/regolith/sway/config.d/87_cosmic-osd
+++ b/usr/share/regolith/sway/config.d/87_cosmic-osd
@@ -1,0 +1,1 @@
+exec cosmic-osd


### PR DESCRIPTION
This replaces the following gnome dependencies with the following cosmic ones.

- [x] `regolith-control-center` -> `cosmic-settings` + `cosmic-settings-daemon`
- [x] + `cosmic-idle`
- [x] `swaybg` -> `cosmic-bg`
- [ ] `gtk_lock` -> ?
- [x] `gnome-session-quit` -> `systemctl`/`loginctl`
- [ ] `gnome-flashback-media-keys` -> ?
- [x] `nautilus` -> `cosmic-files`
- [x] + `cosmic-osd`

The following config can be used with https://github.com/sandptel/regolith-session/tree/cosmic-session inside of the `cosmic-sys-ext` environment as mentioned below. Or can be tested locally 

```bash
git clone https://github.com/sandptel/regolith-wm-config
cd regolith-wm-config

```  
Launch the session using the following
```bash
cosmic-session sway --config ./etc/regolith/sway/config -d
```

This configuration work in pair with the following fork of [cosmic-settings](https://github.com/sandptel/cosmic-settings) that convert the cosmic-settings changes to `sway-ipc` commands via `swayipc-rs` within the application for hot loading the changes and an equivalent sway config is added/changed at `$HOME/.config/regolith3/sway/cosmic-settings/generated-config.d/*`
```
include $HOME/.config/regolith3/sway/cosmic-settings/generated-config.d/*
```

#### Testing Environment
```bash
sudo apt install just rustc libglvnd-dev libwayland-dev libseat-dev libxkbcommon-dev libinput-dev udev dbus libdbus-1-dev libsystemd-dev libpixman-1-dev libssl-dev libflatpak-dev libpulse-dev pop-launcher libexpat1-dev libfontconfig-dev libfreetype-dev mold cargo libgbm-dev libclang-dev libpipewire-0.3-dev libpam0g-dev -y
```
and some extra dependencies I found were missing in the [list](https://github.com/pop-os/cosmic-epoch/blob/cdc45ee666b67a104ac53c7541eb55b37d0cada5/README.md?plain=1#L82) when compiling `cosmic-applets`
```bash
sudo apt install libdisplay-info-dev
sudo apt install gstreamer-sys
sudo apt install libgstreamer1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good
sudo apt install libgstreamer-plugins-base1.0-dev

```

```bash
git clone --recurse-submodules https://github.com/pop-os/cosmic-epoch
cd cosmic-epoch
just sysext
```
